### PR TITLE
SWF-3797: Use build argument for eXo CI user UID

### DIFF
--- a/jdk6-maven30/Dockerfile
+++ b/jdk6-maven30/Dockerfile
@@ -8,6 +8,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 # eXo CI User
+ARG EXO_CI_USER_UID=13000
 ENV EXO_CI_USER ciagent
 ENV EXO_GROUP ciagent
 ENV HOME /home/${EXO_CI_USER}
@@ -22,7 +23,7 @@ ENV EXO_CI_TMP_DIR    ${EXO_CI_BASE}/tmp
 ENV MAVEN_VERSION 3.0.5
 
 # Create user and group with specific ids
-RUN useradd --create-home --user-group -u 13000 --shell /bin/bash ${EXO_CI_USER}
+RUN useradd --create-home --user-group -u ${EXO_CI_USER_UID} --shell /bin/bash ${EXO_CI_USER}
 # giving all rights to eXo CI user
 RUN echo "ciagent  ALL = NOPASSWD: ALL" > /etc/sudoers.d/ciagent && chmod 440 /etc/sudoers.d/ciagent
 

--- a/jdk7-maven30/Dockerfile
+++ b/jdk7-maven30/Dockerfile
@@ -8,6 +8,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 # eXo CI User
+ARG EXO_CI_USER_UID=13000
 ENV EXO_CI_USER ciagent
 ENV EXO_GROUP ciagent
 ENV HOME /home/${EXO_CI_USER}
@@ -22,7 +23,7 @@ ENV EXO_CI_TMP_DIR    ${EXO_CI_BASE}/tmp
 ENV MAVEN_VERSION 3.0.5
 
 # Create user and group with specific ids
-RUN useradd --create-home --user-group -u 13000 --shell /bin/bash ${EXO_CI_USER}
+RUN useradd --create-home --user-group -u ${EXO_CI_USER_UID} --shell /bin/bash ${EXO_CI_USER}
 # giving all rights to eXo CI user
 RUN echo "ciagent  ALL = NOPASSWD: ALL" > /etc/sudoers.d/ciagent && chmod 440 /etc/sudoers.d/ciagent
 

--- a/jdk7-maven32/Dockerfile
+++ b/jdk7-maven32/Dockerfile
@@ -8,6 +8,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 # eXo CI User
+ARG EXO_CI_USER_UID=13000
 ENV EXO_CI_USER ciagent
 ENV EXO_GROUP ciagent
 ENV HOME /home/${EXO_CI_USER}
@@ -22,7 +23,7 @@ ENV EXO_CI_TMP_DIR    ${EXO_CI_BASE}/tmp
 ENV MAVEN_VERSION 3.2.5
 
 # Create user and group with specific ids
-RUN useradd --create-home --user-group -u 13000 --shell /bin/bash ${EXO_CI_USER}
+RUN useradd --create-home --user-group -u ${EXO_CI_USER_UID} --shell /bin/bash ${EXO_CI_USER}
 # giving all rights to eXo CI user
 RUN echo "ciagent  ALL = NOPASSWD: ALL" > /etc/sudoers.d/ciagent && chmod 440 /etc/sudoers.d/ciagent
 

--- a/jdk8-maven30/Dockerfile
+++ b/jdk8-maven30/Dockerfile
@@ -8,6 +8,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 # eXo CI User
+ARG EXO_CI_USER_UID=13000
 ENV EXO_CI_USER ciagent
 ENV EXO_GROUP ciagent
 ENV HOME /home/${EXO_CI_USER}
@@ -22,7 +23,7 @@ ENV EXO_CI_TMP_DIR    ${EXO_CI_BASE}/tmp
 ENV MAVEN_VERSION 3.0.5
 
 # Create user and group with specific ids
-RUN useradd --create-home --user-group -u 13000 --shell /bin/bash ${EXO_CI_USER}
+RUN useradd --create-home --user-group -u ${EXO_CI_USER_UID} --shell /bin/bash ${EXO_CI_USER}
 # giving all rights to eXo CI user
 RUN echo "ciagent  ALL = NOPASSWD: ALL" > /etc/sudoers.d/ciagent && chmod 440 /etc/sudoers.d/ciagent
 

--- a/jdk8-maven32/Dockerfile
+++ b/jdk8-maven32/Dockerfile
@@ -8,6 +8,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 # eXo CI User
+ARG EXO_CI_USER_UID=13000
 ENV EXO_CI_USER ciagent
 ENV EXO_GROUP ciagent
 ENV HOME /home/${EXO_CI_USER}
@@ -22,7 +23,7 @@ ENV EXO_CI_TMP_DIR    ${EXO_CI_BASE}/tmp
 ENV MAVEN_VERSION 3.2.5
 
 # Create user and group with specific ids
-RUN useradd --create-home --user-group -u 13000 --shell /bin/bash ${EXO_CI_USER}
+RUN useradd --create-home --user-group -u ${EXO_CI_USER_UID} --shell /bin/bash ${EXO_CI_USER}
 # giving all rights to eXo CI user
 RUN echo "ciagent  ALL = NOPASSWD: ALL" > /etc/sudoers.d/ciagent && chmod 440 /etc/sudoers.d/ciagent
 


### PR DESCRIPTION
To test it locally (for jdk7-maven32 example) :

$ git clone https://github.com/exo-docker/exo-ci.git
$ cd jdk7-maven32
$ docker build  --build-arg EXO_CI_USER_UID=my_uid -t exoplatform/ci:jdk7-maven32 .
