### PR TITLE
Create maven 3.9 CI image based on Alpine 3.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ It contains **Dockerfiles, Tests and configuration** for the following CI Images
 |    Image                            |  JDK        | Python   | GCC |   Build tool   |  Tests
 |-------------------------------------|-------------|----------|-----|----------------|------------
 | exoplatform/ci:base                 |   n/a       | 2.7 & 3  | 4.8 | n/a            | [goss.yaml](base/tests/goss.yaml)
+| exoplatform/ci:base-alpine          |   n/a       | 2.7 & 3  | 4.8 | n/a            | [goss.yaml](base-alpine/tests/goss.yaml)
 | exoplatform/ci:jdk6                 |   1.6.0_45  | 2.7 & 3  | 4.8 | n/a            | [goss.yaml](jdk/jdk6/tests/goss.yaml)
 | exoplatform/ci:jdk7                 |   1.7.0_80  | 2.7 & 3  | 4.8 | n/a            | [goss.yaml](jdk/jdk7/tests/goss.yaml)
 | exoplatform/ci:jdk8                 |   1.8.0_181 | 2.7 & 3  | 4.8 | n/a            | [goss.yaml](jdk/jdk8/tests/goss.yaml)
 | exoplatform/ci:jdk11                |   11.0.19   | 2.7 & 3  | 4.8 | n/a            | [goss.yaml](jdk/jdk11/tests/goss.yaml)
 | exoplatform/ci:jdk17                |   17.0.7    | 2.7 & 3  | 4.8 | n/a            | [goss.yaml](jdk/jdk17/tests/goss.yaml)
+| exoplatform/ci:jdk17-alpine         |   17.0.7    | 2.7 & 3  | 4.8 | n/a            | [goss.yaml](jdk/jdk17-alpine/tests/goss.yaml)
 | exoplatform/ci:jdk8-gradle2         |   1.8.0_181 | 2.7 & 3  | 4.8 | Gradle 2.14    | [goss.yaml](jdk/jdk8-gradle2/tests/goss.yaml)
 | exoplatform/ci:jdk8-gradle2-android |   1.8.0_181 | 2.7 & 3  | 4.8 | Gradle 2.14 / Android 23/24    | [goss.yaml](gradle/jdk8-gradle2-android/tests/goss.yaml)
 | exoplatform/ci:jdk8-gradle4         |   1.8.0_181 | 2.7 & 3  | 4.8 | Gradle 4.1    | [goss.yaml](jdk/jdk8-gradle4/tests/goss.yaml)
@@ -51,6 +53,7 @@ It contains **Dockerfiles, Tests and configuration** for the following CI Images
 | exoplatform/ci:jdk17-mavend08       |   17.0.7    | 2.7 & 3  | 4.8 | Mavend 0.8.2   | [goss.yaml](mavend/jdk17-mavend08/tests/goss.yaml)
 | exoplatform/ci:jdk17-mavend09       |   17.0.7    | 2.7 & 3  | 4.8 | Mavend 0.9.0   | [goss.yaml](mavend/jdk17-mavend09/tests/goss.yaml)
 | exoplatform/ci:jdk17-maven39        |   17.0.7    | 2.7 & 3  | 4.8 | Maven 3.9.2    | [goss.yaml](maven/jdk17-maven39/tests/goss.yaml)
+| exoplatform/ci:jdk17-maven39-alpine |   17.0.7    | 2.7 & 3  | 4.8 | Maven 3.9.2    | [goss.yaml](maven/jdk17-maven39/tests/goss.yaml)
 
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ It contains **Dockerfiles, Tests and configuration** for the following CI Images
 | exoplatform/ci:jdk17-mavend08       |   17.0.7    | 2.7 & 3  | 4.8 | Mavend 0.8.2   | [goss.yaml](mavend/jdk17-mavend08/tests/goss.yaml)
 | exoplatform/ci:jdk17-mavend09       |   17.0.7    | 2.7 & 3  | 4.8 | Mavend 0.9.0   | [goss.yaml](mavend/jdk17-mavend09/tests/goss.yaml)
 | exoplatform/ci:jdk17-maven39        |   17.0.7    | 2.7 & 3  | 4.8 | Maven 3.9.2    | [goss.yaml](maven/jdk17-maven39/tests/goss.yaml)
-| exoplatform/ci:jdk17-maven39-alpine |   17.0.7    | 2.7 & 3  | 4.8 | Maven 3.9.2    | [goss.yaml](maven/jdk17-maven39/tests/goss.yaml)
+| exoplatform/ci:jdk17-maven39-alpine |   17.0.7    | 2.7 & 3  | 4.8 | Maven 3.9.2    | [goss.yaml](maven/jdk17-maven39-alpine/tests/goss.yaml)
 
 
 ## Overview

--- a/base-alpine/Dockerfile
+++ b/base-alpine/Dockerfile
@@ -1,0 +1,64 @@
+# Dockerizing a base images with:
+#
+#   - alpine 3.18
+#   - Base eXo CI Configuration
+#
+# build :   docker build -t exoplatform/ci:base-alpine .
+#
+
+FROM  alpine:3.18
+LABEL MAINTAINER "eXo Platform <docker@exoplatform.com>"
+
+# Install some useful or needed tools
+RUN apk update && \
+  apk upgrade && \
+  apk add --no-cache xmlstarlet jq bash wget curl htop unzip git git-lfs make python3 sudo xterm github-cli expect busybox sed
+
+ENV TERM xterm
+
+# Set the locale
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+RUN fc-cache -f
+
+# Install yq
+RUN wget -nv -q -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_linux_amd64 && \
+  echo "fe08cd1b6c23c8c5bf4f94e0f9d4b5b2 /usr/bin/yq" | md5sum -c - \
+  || { \
+  echo "ERROR: the [/usr/bin/yq] binary downloaded from a github release was modified while is should not !!"; \
+  return 1; \
+  } && chmod a+x /usr/bin/yq
+
+# Add some aliases
+RUN echo "alias ll='ls -al --color'" > /etc/profile.d/aliases.sh
+
+# Configure htop for root user
+RUN mkdir -p /root/.config/htop/ && chmod -R 700 /root/.config/htop/
+ADD conf/htoprc.conf /root/.config/htop/htoprc
+
+
+####
+# eXo CI User
+###
+ARG EXO_CI_USER_UID=13000
+ENV EXO_CI_USER ciagent
+ENV EXO_GROUP ciagent
+ENV HOME /home/${EXO_CI_USER}
+
+# Required directories for ciagent
+ENV EXO_CI_BASE       /srv/ciagent
+ENV EXO_CI_DATA_DIR   ${EXO_CI_BASE}/workspace
+ENV EXO_CI_LOG_DIR    ${EXO_CI_BASE}/logs
+ENV EXO_CI_TMP_DIR    ${EXO_CI_BASE}/tmp
+
+# - Create user and group with specific ids
+# - giving all rights to eXo CI user
+# - Create needed directories
+RUN addgroup -g ${EXO_CI_USER_UID} ${EXO_CI_USER}
+RUN adduser -u ${EXO_CI_USER_UID} -G ${EXO_CI_USER} -s /bin/bash --disabled-password ${EXO_CI_USER} \
+   && echo "ciagent  ALL = NOPASSWD: ALL" > /etc/sudoers.d/ciagent && chmod 440 /etc/sudoers.d/ciagent \
+   && mkdir -p ${EXO_CI_DATA_DIR}  \
+   && mkdir -p ${EXO_CI_TMP_DIR} \
+   && mkdir -p ${EXO_CI_LOG_DIR} \
+   && chown -R ${EXO_CI_USER}:${EXO_GROUP} ${EXO_CI_BASE}

--- a/base-alpine/Dockerfile
+++ b/base-alpine/Dockerfile
@@ -12,7 +12,7 @@ LABEL MAINTAINER "eXo Platform <docker@exoplatform.com>"
 # Install some useful or needed tools
 RUN apk update && \
   apk upgrade && \
-  apk add --no-cache xmlstarlet jq bash wget curl htop unzip git git-lfs make python3 sudo xterm github-cli expect busybox sed yq
+  apk add --no-cache xmlstarlet jq bash wget curl htop unzip git git-lfs make python3 sudo xterm github-cli expect busybox sed yq gnupg
 
 ENV TERM xterm
 

--- a/base-alpine/Dockerfile
+++ b/base-alpine/Dockerfile
@@ -12,7 +12,7 @@ LABEL MAINTAINER "eXo Platform <docker@exoplatform.com>"
 # Install some useful or needed tools
 RUN apk update && \
   apk upgrade && \
-  apk add --no-cache xmlstarlet jq bash wget curl htop unzip git git-lfs make python3 sudo xterm github-cli expect busybox sed
+  apk add --no-cache xmlstarlet jq bash wget curl htop unzip git git-lfs make python3 sudo xterm github-cli expect busybox sed yq
 
 ENV TERM xterm
 
@@ -21,14 +21,6 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 RUN fc-cache -f
-
-# Install yq
-RUN wget -nv -q -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_linux_amd64 && \
-  echo "fe08cd1b6c23c8c5bf4f94e0f9d4b5b2 /usr/bin/yq" | md5sum -c - \
-  || { \
-  echo "ERROR: the [/usr/bin/yq] binary downloaded from a github release was modified while is should not !!"; \
-  return 1; \
-  } && chmod a+x /usr/bin/yq
 
 # Add some aliases
 RUN echo "alias ll='ls -al --color'" > /etc/profile.d/aliases.sh

--- a/base-alpine/Dockerfile
+++ b/base-alpine/Dockerfile
@@ -22,6 +22,9 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 RUN fc-cache -f
 
+# Specify primary prompt string for bash navigation
+ENV PS1                    "\u@\h:\w$ "
+
 # Add some aliases
 RUN echo "alias ll='ls -al --color'" > /etc/profile.d/aliases.sh
 

--- a/base-alpine/conf/htoprc.conf
+++ b/base-alpine/conf/htoprc.conf
@@ -1,0 +1,24 @@
+# Beware! This file is rewritten by htop when settings are changed in the interface.
+# The parser is also very primitive, and not human-friendly.
+fields=0 48 17 18 38 39 40 2 46 47 49 1
+sort_key=46
+sort_direction=1
+hide_threads=0
+hide_kernel_threads=1
+hide_userland_threads=1
+shadow_other_users=0
+show_thread_names=0
+highlight_base_name=1
+highlight_megabytes=1
+highlight_threads=0
+tree_view=1
+header_margin=1
+detailed_cpu_time=0
+cpu_count_from_zero=0
+update_process_names=0
+color_scheme=0
+delay=15
+left_meters=LeftCPUs Memory Swap
+left_meter_modes=1 1 1
+right_meters=RightCPUs Tasks LoadAverage Uptime
+right_meter_modes=1 2 2 2

--- a/base-alpine/tests/goss.yaml
+++ b/base-alpine/tests/goss.yaml
@@ -1,0 +1,26 @@
+file:
+  /root/.config/htop/htoprc:
+    title: Validating the presence of htop conf file
+    exists: true
+  /home/ciagent:
+    title: Validating the home path for eXo CI Agent user
+    exists: true
+package:
+  git:
+    installed: true
+    title: Check that git is installed
+  make:
+    installed: true
+    title: Check that make is installed
+  python3:
+    installed: true
+    title: Check that Python 3 is installed
+  sed:
+    installed: true
+    title: Check that sed is installed
+  unzip:
+    installed: true
+    title: Check that unzip is installed
+  wget:
+    installed: true
+    title: Check that wget is installed

--- a/base-alpine/tests/test_image.sh
+++ b/base-alpine/tests/test_image.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+i=0
+time dgoss run -it exoplatform/ci:base-alpine /bin/cat || ((i++))
+
+exit $i

--- a/jdk/jdk17-alpine/Dockerfile
+++ b/jdk/jdk17-alpine/Dockerfile
@@ -1,0 +1,12 @@
+# Dockerizing a jdk17 images with:
+#
+#   - OpenJDK JDK 17
+#
+# build :   docker build -t exoplatform/ci:jdk17-alpine .
+#
+FROM exoplatform/ci:base-alpine
+LABEL MAINTAINER "eXo Platform <docker@exoplatform.com>"
+
+ENV TERM xterm
+
+RUN apk add --no-cache openjdk17-jdk

--- a/jdk/jdk17-alpine/tests/goss.yaml
+++ b/jdk/jdk17-alpine/tests/goss.yaml
@@ -1,0 +1,15 @@
+file:
+  /usr/lib/jvm:
+    title: Validating the presence of JVM directory
+    exists: true   
+package:
+  git:
+    installed: true
+    title: Check that git is installed
+command:
+  java -version:
+    exit-status: 0
+    stdout: []
+    stderr:
+    - openjdk version "17.0.7"
+    timeout: 0

--- a/jdk/jdk17-alpine/tests/test_image.sh
+++ b/jdk/jdk17-alpine/tests/test_image.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+i=0
+time dgoss run -it exoplatform/ci:jdk17-alpine /bin/cat || ((i++))
+
+exit $i

--- a/maven/jdk17-maven39-alpine/Dockerfile
+++ b/maven/jdk17-maven39-alpine/Dockerfile
@@ -29,6 +29,7 @@ RUN  chown ${EXO_CI_USER}:${EXO_GROUP} ${HOME}/.web3j
 
 # Custom configuration for Maven
 ENV M2_HOME=/usr/share/maven
+# Alpine (musl) Do not override nodejs download URL; tl;dr https://github.com/eirslett/frontend-maven-plugin/issues/965
 ENV MAVEN_OPTS="-Dmaven.repo.local=${HOME}/.m2/repository -Xms1G -Xmx2G -XX:MaxMetaspaceSize=1G -Dcom.sun.media.jai.disableMediaLib=true -Djava.io.tmpdir=${EXO_CI_TMP_DIR} -Dmaven.artifact.threads=10 -Djava.awt.headless=true --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens java.base/java.nio.charset=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED -DnpmDownloadRoot=https://registry.npmmirror.com/npm/-/"
 ENV PATH=$JAVA_HOME/bin:$M2_HOME/bin:$PATH
 

--- a/maven/jdk17-maven39-alpine/Dockerfile
+++ b/maven/jdk17-maven39-alpine/Dockerfile
@@ -1,0 +1,46 @@
+# Dockerizing a jdk17-maven39-alpine images with:
+#   - alpine 3.18
+#   - OpenJDK JDK 17
+#   - Maven 3.9
+#
+# build :   docker build -t exoplatform/ci:jdk17-maven39-alpine .
+#
+FROM exoplatform/ci:jdk17-alpine
+LABEL MAINTAINER "eXo Platform <docker@exoplatform.com>"
+
+# CI Tools version
+ENV MAVEN_VERSION 3.9.2
+# Install Maven
+RUN mkdir -p /usr/share/maven \
+    && curl -fsSL http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
+         | tar xzf - -C /usr/share/maven --strip-components=1  \
+    && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+# Workaround to be able to execute others command than "mvn" as entrypoint
+COPY docker-entrypoint.sh /usr/bin/docker-entrypoint
+RUN  chown ${EXO_CI_USER}:${EXO_GROUP} /usr/bin/docker-entrypoint \
+     && chmod u+x /usr/bin/docker-entrypoint
+
+USER ${EXO_CI_USER}
+
+RUN mkdir -p ${HOME}/.web3j/solc
+COPY releases.json ${HOME}/.web3j/solc/
+RUN  chown ${EXO_CI_USER}:${EXO_GROUP} ${HOME}/.web3j
+
+# Custom configuration for Maven
+ENV M2_HOME=/usr/share/maven
+ENV MAVEN_OPTS="-Dmaven.repo.local=${HOME}/.m2/repository -Xms1G -Xmx2G -XX:MaxMetaspaceSize=1G -Dcom.sun.media.jai.disableMediaLib=true -Djava.io.tmpdir=${EXO_CI_TMP_DIR} -Dmaven.artifact.threads=10 -Djava.awt.headless=true --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens java.base/java.nio.charset=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED -DnodeDownloadRoot=https://cdn.npmmirror.com/binaries/node/ -DnpmDownloadRoot=https://registry.npmmirror.com/npm/-/"
+ENV PATH=$JAVA_HOME/bin:$M2_HOME/bin:$PATH
+
+# Create needed directories for Maven & git
+RUN mkdir -p ${HOME}/.m2/repository \
+    && mkdir -p ${HOME}/.ssh \
+    && mkdir -p ${HOME}/.gnupg \
+    && chmod 700 ${HOME}/.gnupg 
+
+WORKDIR ${EXO_CI_DATA_DIR}
+
+# Workaround to be able to execute others command than "mvn" as entrypoint
+ENTRYPOINT ["/usr/bin/docker-entrypoint"]
+
+CMD ["mvn", "--help"]

--- a/maven/jdk17-maven39-alpine/Dockerfile
+++ b/maven/jdk17-maven39-alpine/Dockerfile
@@ -29,7 +29,7 @@ RUN  chown ${EXO_CI_USER}:${EXO_GROUP} ${HOME}/.web3j
 
 # Custom configuration for Maven
 ENV M2_HOME=/usr/share/maven
-ENV MAVEN_OPTS="-Dmaven.repo.local=${HOME}/.m2/repository -Xms1G -Xmx2G -XX:MaxMetaspaceSize=1G -Dcom.sun.media.jai.disableMediaLib=true -Djava.io.tmpdir=${EXO_CI_TMP_DIR} -Dmaven.artifact.threads=10 -Djava.awt.headless=true --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens java.base/java.nio.charset=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED -DnodeDownloadRoot=https://cdn.npmmirror.com/binaries/node/ -DnpmDownloadRoot=https://registry.npmmirror.com/npm/-/"
+ENV MAVEN_OPTS="-Dmaven.repo.local=${HOME}/.m2/repository -Xms1G -Xmx2G -XX:MaxMetaspaceSize=1G -Dcom.sun.media.jai.disableMediaLib=true -Djava.io.tmpdir=${EXO_CI_TMP_DIR} -Dmaven.artifact.threads=10 -Djava.awt.headless=true --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens java.base/java.nio.charset=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED -DnpmDownloadRoot=https://registry.npmmirror.com/npm/-/"
 ENV PATH=$JAVA_HOME/bin:$M2_HOME/bin:$PATH
 
 # Create needed directories for Maven & git

--- a/maven/jdk17-maven39-alpine/docker-entrypoint.sh
+++ b/maven/jdk17-maven39-alpine/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Hack for Jenkins Pipeline: authorize cat without absolute path
+if [[ "$1" == "/"* ]] || [[ "$1" == "cat" ]]; then
+  exec "$@"
+fi
+
+exec mvn "$@"

--- a/maven/jdk17-maven39-alpine/releases.json
+++ b/maven/jdk17-maven39-alpine/releases.json
@@ -1,0 +1,356 @@
+[
+    {
+    "version": "0.4.16",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.16/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.16/solc-static-linux"
+    },
+    {
+    "version": "0.4.17",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.17/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.17/solc-static-linux"
+    },
+    {
+    "version": "0.4.18",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.18/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.18/solc-static-linux"
+    },
+    {
+    "version": "0.4.19",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.19/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.19/solc-static-linux"
+    },
+    {
+    "version": "0.4.20",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.20/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.20/solc-static-linux"
+    },
+    {
+    "version": "0.4.21",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.21/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.21/solc-static-linux"
+    },
+    {
+    "version": "0.4.22",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.22/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.22/solc-static-linux"
+    },
+    {
+    "version": "0.4.23",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.23/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.23/solc-static-linux"
+    },
+    {
+    "version": "0.4.24",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.24/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.24/solc-static-linux"
+    },
+    {
+    "version": "0.4.25",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.25/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.4.25/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux"
+    },
+    {
+    "version": "0.4.26",
+    "windows_url": "",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.26/solc-static-linux"
+    },
+    {
+    "version": "0.5.0",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.0/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.0/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.0/solc-static-linux"
+    },
+    {
+    "version": "0.5.1",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.1/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.1/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.1/solc-static-linux"
+    },
+    {
+    "version": "0.5.2",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.2/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.2/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.2/solc-static-linux"
+    },
+    {
+    "version": "0.5.3",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.3/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.3/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.3/solc-static-linux"
+    },
+    {
+    "version": "0.5.4",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.4/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.4/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.4/solc-static-linux"
+    },
+    {
+    "version": "0.5.5",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.5/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.5/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.5/solc-static-linux"
+    },
+    {
+    "version": "0.5.6",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.6/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.6/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.6/solc-static-linux"
+    },
+    {
+    "version": "0.5.7",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.7/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.7/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.7/solc-static-linux"
+    },
+    {
+    "version": "0.5.8",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.8/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.8/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.8/solc-static-linux"
+    },
+    {
+    "version": "0.5.9",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.9/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.9/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.9/solc-static-linux"
+    },
+    {
+    "version": "0.5.10",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.10/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.10/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.10/solc-static-linux"
+    },
+    {
+    "version": "0.5.11",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.11/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.11/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.11/solc-static-linux"
+    },
+    {
+    "version": "0.5.12",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.12/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.12/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.12/solc-static-linux"
+    },
+    {
+    "version": "0.5.13",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.13/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.13/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.13/solc-static-linux"
+    },
+    {
+    "version": "0.5.14",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.14/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.14/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.14/solc-static-linux"
+    },
+    {
+    "version": "0.5.15",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.15/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.15/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.15/solc-static-linux"
+    },
+    {
+    "version": "0.5.16",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.16/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.16/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.16/solc-static-linux"
+    },
+    {
+    "version": "0.5.17",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.17/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.17/solc-static-linux"
+    },
+    {
+    "version": "0.6.0",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.0/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.6.0/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.0/solc-static-linux"
+    },
+    {
+    "version": "0.6.1",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.1/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.6.1/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.1/solc-static-linux"
+    },
+    {
+    "version": "0.6.2",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.2/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.6.2/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.2/solc-static-linux"
+    },
+    {
+    "version": "0.6.3",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.3/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.3/solc-static-linux"
+    },
+    {
+    "version": "0.6.4",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.4/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.4/solc-static-linux"
+    },
+    {
+    "version": "0.6.5",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.5/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.5/solc-static-linux"
+    },
+    {
+    "version": "0.6.6",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.6/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.6/solc-static-linux"
+    },
+    {
+    "version": "0.6.7",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.7/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.7/solc-static-linux"
+    },
+    {
+    "version": "0.6.8",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.8/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.8/solc-static-linux"
+    },
+    {
+    "version": "0.6.9",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.9/solidity-windows.zip",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.6.9/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.9/solc-static-linux"
+    },
+    {
+    "version": "0.6.10",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.10/solidity-windows.zip",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.6.10/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.10/solc-static-linux"
+    },
+    {
+    "version": "0.6.11",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.11/solidity-windows.zip",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.6.11/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.11/solc-static-linux"
+    },
+    {
+    "version": "0.6.12",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.12/solidity-windows.zip",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.6.12/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.12/solc-static-linux"
+    },
+    {
+    "version": "0.7.0",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.7.0/solidity-windows.zip",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.0/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.0/solc-static-linux"
+    },
+    {
+    "version": "0.7.1",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.7.1/solidity-windows.zip",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.1/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.1/solc-static-linux"
+    },
+    {
+    "version": "0.7.2",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.2/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.2/solc-static-linux"
+    },
+    {
+    "version": "0.7.3",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.3/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.3/solc-static-linux"
+    },
+    {
+    "version": "0.7.4",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.4/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.4/solc-static-linux"
+    },
+    {
+    "version": "0.7.5",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.5/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.5/solc-static-linux"
+    },
+    {
+    "version": "0.7.6",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.6/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.6/solc-static-linux"
+    },
+    {
+    "version": "0.8.0",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.0/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.0/solc-static-linux"
+    },
+    {
+    "version": "0.8.1",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.1/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.1/solc-static-linux"
+    },
+    {
+    "version": "0.8.2",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.2/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.2/solc-static-linux"
+    },
+    {
+    "version": "0.8.3",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.3/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.3/solc-static-linux"
+    },
+    {
+    "version": "0.8.4",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.4/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.4/solc-static-linux"
+    },
+    {
+    "version": "0.8.5",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.5/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.5/solc-static-linux"
+    },
+    {
+    "version": "0.8.6",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.6/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.6/solc-static-linux"
+    },
+    {
+    "version": "0.8.7",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.7/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.7/solc-static-linux"
+    },
+    {
+    "version": "0.8.8",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.8/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.8/solc-static-linux"
+    },
+    {
+    "version": "0.8.9",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.9/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.9/solc-static-linux"
+    }
+]

--- a/maven/jdk17-maven39-alpine/tests/goss.yaml
+++ b/maven/jdk17-maven39-alpine/tests/goss.yaml
@@ -1,0 +1,23 @@
+file:
+  /home/ciagent/.m2/repository:
+    title: Validating the presence Maven repository folder
+    exists: true
+  /home/ciagent/.m2/settings.xml:
+    title: Validating the absence of eXo USER settings file
+    exists: false   
+  /usr/share/maven/conf/settings.xml:
+    title: Validating the presence of eXo GLOBAL settings file
+    exists: true      
+package:
+  git:
+    installed: true
+    title: Check that git is installed
+command:
+  mvn --version:
+    exit-status: 0
+    stdout:
+    - 3.9.2
+    - 17.0.7
+    - "Default locale: en_US, platform encoding: UTF-8"
+    stderr: []
+    timeout: 0

--- a/maven/jdk17-maven39-alpine/tests/test_image.sh
+++ b/maven/jdk17-maven39-alpine/tests/test_image.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+i=0
+time dgoss run -it exoplatform/ci:jdk17-maven39-alpine cat || ((i++))
+
+exit $i


### PR DESCRIPTION
Create images based on alpine `3.18` :
- CI Base 
- JDK 17 (non-Temurin out the box build)
- Maven 3.9 JDK 17 

Dropped package
- Python 2.7

ℹ️ Nodejs download URL override has been removed since nodejs requires glibc musl (maven frontend plugin handles this case. https://github.com/eirslett/frontend-maven-plugin/blob/e864cf81b25e7b80334fd094e11a15ec7a78945e/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java#L120)